### PR TITLE
initialize text color

### DIFF
--- a/ios/StrokeTextView.swift
+++ b/ios/StrokeTextView.swift
@@ -11,7 +11,7 @@ class StrokeTextView: RCTView {
         label = StrokedTextLabel()
         self.bridge = bridge
         super.init(frame: .zero)
-
+        label.textColor = colorStringToUIColor(colorString: color)
         label.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(label)
         NSLayoutConstraint.activate([

--- a/ios/StrokeTextView.swift
+++ b/ios/StrokeTextView.swift
@@ -12,6 +12,7 @@ class StrokeTextView: RCTView {
         self.bridge = bridge
         super.init(frame: .zero)
         label.textColor = colorStringToUIColor(colorString: color)
+        label.outlineColor = colorStringToUIColor(colorString: strokeColor)
         label.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(label)
         NSLayoutConstraint.activate([


### PR DESCRIPTION
fix for iOS Dark Appearance bug where text renders as white when given a color of #000000 on first render

fixes #28 

second commit fixes initial stroke color of #FFFFFF